### PR TITLE
Fix loop while reading from standalone evtx

### DIFF
--- a/winlogbeat/beater/eventlogger.go
+++ b/winlogbeat/beater/eventlogger.go
@@ -171,6 +171,9 @@ runLoop:
 			e.log.Debugf("Read() returned %d records.", len(records))
 			if len(records) == 0 {
 				time.Sleep(time.Second)
+				if stop {
+					return
+				}
 				continue
 			}
 


### PR DESCRIPTION
## What does this PR do?

Tjis fix adds checking EOF to prevent constant loop while reading standalone evtx file


## Why is it important?

When we reach the end of the file (case io.EOF) we set stop = true.
But next we continue the loop regardless stop value and read whole file again and again. 

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.


